### PR TITLE
fix intent-filter to match either mime-type or uri

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,8 +28,6 @@
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
 
-                <data android:scheme="content" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
@@ -52,21 +50,12 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="file" />
+                <data android:scheme="content" />
 
                 <data android:mimeType="*/*" />
                 <data android:host="*" />
                 <data android:pathPattern=".*\\.gpx" />
                 <data android:pathPattern=".*\\.fit" />
-            </intent-filter>
-            <!-- Workaround for stupid file browsers -->
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:mimeType="application/octet-stream" />
             </intent-filter>
 
         </activity>


### PR DESCRIPTION
the intent-filters fail if the intent comes with a mime-type only, and does not have an Uri in data but in extras. (You cannot match Uris of intent-extras).
This is the case when sharing the current route by OsmAnd. OsmAnd sets the mime-type of the intent to 'text/plain' and puts both a description of the route (as plain text) plus the current track (accessible via content-scheme Uri) into the intents extras. So the intent does not have an Uri within it's data (and as it contains both the text-representation plus the attachment it does not really make sense to add an Uri specific to one of the parts into the intents data).

To match such intent one must match the mime-type only.

see https://developer.android.com/guide/components/intents-filters section 'Data test' listing the 4 rules that describe matching behaviour depending on mime-type and/or Uri being set in intent data.

This PR ensures that an intent that has a matching mime-type set, or has an Uri set with any mime-type will allow to launch gexporter.