### PR TITLE
Parse symbole and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ Android App to export GPX and FIT to garmin devices
 * see Wiki: https://github.com/gimportexportdevs/gexporter/wiki/Help
 
 ## HOWTO Develop
-* create directory app/libs
-* copy fit.jar from the [Garmin FitSDK](https://developer.garmin.com/fit/download/) to app/libs
-* Download the [Connect IQ Mobile SDK (Android BLE/ADB)](https://developer.garmin.com/connect-iq/sdk/) and copy the .aar file to app/libs
 * Android Studio -> Settings -> System Settings -> Android SDK -> "SDK Tools" Tab -> Check "Support Repository/Constraint Layout"
 * start TestServer.main() (this fires up the webserver on localhost)
 * develop with the ConnectIQ simulator (connects to the webserver on localhost)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,10 +39,10 @@ dependencies {
 
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
     implementation 'org.gavaghan:geodesy:1.1.3'
-    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'org.slf4j:slf4j-api:2.0.9'
     runtimeOnly 'org.slf4j:slf4j-android:1.7.30'
 
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 
@@ -56,7 +56,7 @@ dependencies {
 //    androidTestImplementation 'xmlpull:xmlpull:1.1.3.1'
 //    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation  'net.sf.kxml:kxml2:2.3.0'
-    testImplementation 'org.slf4j:slf4j-api:1.7.30'
+    testImplementation 'org.slf4j:slf4j-api:2.0.9'
 
     //testImplementation 'xmlpull:xmlpull:1.1.3.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 
-    implementation files('libs/fit.jar')
-    implementation files('libs/connectiq-mobile-sdk-android-1.5.aar')
+    implementation 'com.garmin:fit:21.120.0'
+    implementation 'com.garmin.connectiq:ciq-companion-app-sdk:2.0.3@aar'
 
 //    androidTestImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 //    androidTestImplementation group: 'xpp3', name: 'xpp3_min', version: '1.1.3.4.O'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.8.6'
 
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
+
     implementation files('libs/fit.jar')
     implementation files('libs/connectiq-mobile-sdk-android-1.5.aar')
 

--- a/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
+++ b/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
@@ -168,25 +168,23 @@ public class Gpx2Fit {
         return txt;
     }
 
-    private String readName(XmlPullParser parser) throws IOException, XmlPullParserException {
-        parser.require(XmlPullParser.START_TAG, ns, "name");
+    private String readSimpleTextTag(XmlPullParser parser, String tagName) throws IOException, XmlPullParserException {
+        parser.require(XmlPullParser.START_TAG, ns, tagName);
         String txt = readText(parser);
-        parser.require(XmlPullParser.END_TAG, ns, "name");
+        parser.require(XmlPullParser.END_TAG, ns, tagName);
         return txt;
+    }
+
+    private String readName(XmlPullParser parser) throws IOException, XmlPullParserException {
+        return readSimpleTextTag(parser, "name");
     }
 
     private String readType(XmlPullParser parser) throws IOException, XmlPullParserException {
-        parser.require(XmlPullParser.START_TAG, ns, "type");
-        String txt = readText(parser);
-        parser.require(XmlPullParser.END_TAG, ns, "type");
-        return txt;
+        return readSimpleTextTag(parser, "type");
     }
 
     private String readSymbol(XmlPullParser parser) throws IOException, XmlPullParserException {
-        parser.require(XmlPullParser.START_TAG, ns, "sym");
-        String txt = readText(parser);
-        parser.require(XmlPullParser.END_TAG, ns, "sym");
-        return txt;
+        return readSimpleTextTag(parser, "sym");
     }
 
     private void readTrkSeg(XmlPullParser parser) throws XmlPullParserException, IOException, ParseException {

--- a/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
+++ b/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
@@ -366,8 +366,9 @@ public class Gpx2Fit {
      * Grade adjusted pace based on a study by Alberto E. Minetti on the energy cost of
      * walking and running at extreme slopes.
      * <p>
-     * see Minetti, A. E. et al. (2002). Energy cost of walking and running at extreme uphill and downhill slopes.
-     * Journal of Applied Physiology 93, 1039-1046, http://jap.physiology.org/content/93/3/1039.full
+     * see <a href="http://jap.physiology.org/content/93/3/1039.full">Minetti, A. E. et al. (2002).
+     * Energy cost of walking and running at extreme uphill and downhill slopes.
+     * Journal of Applied Physiology 93, 1039-1046</a>
      */
     public double getWalkingGradeFactor(double g) {
         return 1.0 + (g * (19.5 + g * (46.3 + g * (-43.3 + g * (-30.4 + g * 155.4))))) / 3.6;
@@ -559,14 +560,8 @@ public class Gpx2Fit {
                 lapMesg.setFieldValue(28, 0, (Integer) WayPoint.toSemiCircles(maxLong), '\uffff');
                 lapMesg.setFieldValue(29, 0, (Integer) WayPoint.toSemiCircles(minLat), '\uffff');
                 lapMesg.setFieldValue(30, 0, (Integer) WayPoint.toSemiCircles(minLong), '\uffff');
-            } catch (NoSuchMethodException e) {
-                ;
-            } catch (IllegalAccessException e) {
-                ;
-            } catch (InstantiationException e) {
-                ;
-            } catch (InvocationTargetException e) {
-                ;
+            } catch (NoSuchMethodException | IllegalAccessException | InstantiationException |
+                     InvocationTargetException ignored) {
             }
 
             encode.write(lapMesg);

--- a/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
+++ b/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
@@ -1,5 +1,7 @@
 package org.surfsite.gexporter;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import android.annotation.SuppressLint;
 
 import com.garmin.fit.CourseMesg;
@@ -737,12 +739,7 @@ public class Gpx2Fit {
 
             cp.setPositionLat(wpt.getLatSemi());
             cp.setPositionLong(wpt.getLonSemi());
-            String name = wpt.getName();
-            if (name != null) {
-                cp.setName(name);
-            } else {
-                cp.setName("");
-            }
+            cp.setName(defaultString(wpt.getName()));
             cp.setType(wpt.getPointType());
             encode.write(cp);
         }

--- a/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
+++ b/app/src/main/java/org/surfsite/gexporter/Gpx2Fit.java
@@ -26,12 +26,9 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
@@ -39,7 +36,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Scanner;
 
 public class Gpx2Fit {
     private static final Logger Log = LoggerFactory.getLogger(Gpx2Fit.class);

--- a/app/src/main/java/org/surfsite/gexporter/WayPoint.java
+++ b/app/src/main/java/org/surfsite/gexporter/WayPoint.java
@@ -1,5 +1,10 @@
 package org.surfsite.gexporter;
 
+import static org.apache.commons.lang3.StringUtils.isNumeric;
+import static org.apache.commons.lang3.math.NumberUtils.toShort;
+
+import com.garmin.fit.CoursePoint;
+
 import org.gavaghan.geodesy.Ellipsoid;
 import org.gavaghan.geodesy.GeodeticCalculator;
 import org.gavaghan.geodesy.GlobalCoordinates;
@@ -24,7 +29,10 @@ public class WayPoint {
     private double totaldist = Double.NaN;
     private String name = null;
 
-    public WayPoint(String name, double lat, double lon, double ele, Date time) {
+    private String type = null;
+    private String symbol = null;
+
+    public WayPoint(String name, double lat, double lon, double ele, Date time, String type, String symbol) {
         this.lat = lat;
         this.lon = lon;
         this.ele = ele;
@@ -33,6 +41,8 @@ public class WayPoint {
         if (this.time == null) {
             this.time = RefDate;
         }
+        this.type = type;
+        this.symbol = symbol;
     }
 
     public String getName() {
@@ -67,6 +77,15 @@ public class WayPoint {
     public Date getTime() {
         return time;
     }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
     public void setLat(double lat) {
         this.lat = lat;
     }
@@ -81,6 +100,14 @@ public class WayPoint {
 
     public void setTime(Date time) {
         this.time = time;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
     }
 
     public double distance(WayPoint other) {
@@ -110,4 +137,25 @@ public class WayPoint {
         this.totaldist = totaldist;
     }
 
+    public CoursePoint getPointType() {
+        if (parseStringToCoursePoint(type) != null) {
+            return parseStringToCoursePoint(type);
+        }
+        if (parseStringToCoursePoint(symbol) != null) {
+            return parseStringToCoursePoint(symbol);
+        }
+        return CoursePoint.GENERIC;
+    }
+
+    private CoursePoint parseStringToCoursePoint(String s) {
+        if (isNumeric(s)) {
+            return CoursePoint.getByValue(toShort(s));
+        } else {
+            try {
+                return CoursePoint.valueOf(s);
+            } catch (IllegalArgumentException exception) {
+                return null;
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/surfsite/gexporter/WayPoint.java
+++ b/app/src/main/java/org/surfsite/gexporter/WayPoint.java
@@ -22,15 +22,15 @@ public class WayPoint {
     // select a reference ellipsoid
     private static final Ellipsoid reference = Ellipsoid.WGS84;
 
-    private double lat = Double.NaN;
-    private double lon = Double.NaN;
-    private double ele = Double.NaN;
-    private Date time = null;
+    private double lat;
+    private double lon;
+    private double ele;
+    private Date time;
     private double totaldist = Double.NaN;
-    private String name = null;
+    private String name;
 
-    private String type = null;
-    private String symbol = null;
+    private String type;
+    private String symbol;
 
     public WayPoint(String name, double lat, double lon, double ele, Date time, String type, String symbol) {
         this.lat = lat;

--- a/app/src/main/java/org/surfsite/gexporter/WebServer.java
+++ b/app/src/main/java/org/surfsite/gexporter/WebServer.java
@@ -10,15 +10,14 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
-
-import fi.iki.elonen.NanoHTTPD;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import fi.iki.elonen.NanoHTTPD;
 
 public class WebServer extends NanoHTTPD {
     private static final Logger Log = LoggerFactory.getLogger(NanoHTTPD.class);


### PR DESCRIPTION
The main change here is that when `type` and `sym` tags in gpx files are considered. They are used to determine the `type` of course points. The logic is: if there is a `type` parse it. If that fails `sym` is used. If parsing fails again use the `GENERIC` type.

Also some clean ups are done